### PR TITLE
add Connection to wrap Socket, return new Connection in Socket.accept()

### DIFF
--- a/src/main/java/io/github/lottetreg/echo/Connection.java
+++ b/src/main/java/io/github/lottetreg/echo/Connection.java
@@ -1,17 +1,11 @@
 package io.github.lottetreg.echo;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.net.Socket;
 
 public class Connection {
-  ServerSocket socket;
+  public Socket socket;
 
-  Connection(ServerSocket socket) {
+  Connection(Socket socket) {
     this.socket = socket;
-  }
-
-  public Socket accept() throws IOException {
-    return socket.accept();
   }
 }

--- a/src/main/java/io/github/lottetreg/echo/EchoServer.java
+++ b/src/main/java/io/github/lottetreg/echo/EchoServer.java
@@ -1,17 +1,12 @@
 package io.github.lottetreg.echo;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-
 public class EchoServer {
   public static void main(String[] args) {
     int portNumber = new ArgumentParser().parse(args);
-    try {
-      ServerSocket serverSocket = new ServerSocket(portNumber);
-      System.out.println("Waiting for connection");
-      serverSocket.accept();
-      System.out.println("Connection accepted");
-    } catch(IOException e) {
-    }
+    Socket socket = new Socket();
+    socket.setPort(portNumber);
+
+    System.out.println("Waiting for connection");
+    socket.acceptConnection();
   }
 }

--- a/src/main/java/io/github/lottetreg/echo/Socket.java
+++ b/src/main/java/io/github/lottetreg/echo/Socket.java
@@ -4,42 +4,49 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 
-
 public class Socket {
   public ServerSocket serverSocket;
 
- public Socket() {
-   try {
-     this.serverSocket = new ServerSocket();
-   } catch (IOException e) {
-     this.serverSocket = null;
-   }
- }
+  public Socket() {
+    try {
+      this.serverSocket = new ServerSocket();
+    } catch (IOException e) {
+      this.serverSocket = null;
+    }
+  }
 
- public void setServerSocket(ServerSocket serverSocket) {
-   this.serverSocket = serverSocket;
- }
+  public void setServerSocket(ServerSocket serverSocket) {
+    this.serverSocket = serverSocket;
+  }
 
- public void setPort(int portNumber) {
-   String hostname = "0.0.0.0";
-   InetSocketAddress socketAddress = new InetSocketAddress(hostname, portNumber);
-   try {
-     this.serverSocket.bind(socketAddress);
-   } catch (IOException e) {
-     System.out.println(e.getStackTrace());
-   }
- }
+  public void setPort(int portNumber) {
+    String hostname = "0.0.0.0";
+    InetSocketAddress socketAddress = new InetSocketAddress(hostname, portNumber);
+    try {
+      this.serverSocket.bind(socketAddress);
+    } catch (IOException e) {
+      System.out.println(e.getStackTrace());
+    }
+  }
 
- public void acceptConnection() {
-   try {
-     this.serverSocket.accept();
-   } catch (IOException e) {
-     System.out.println(e.getStackTrace());
-   }
- }
+  public Connection acceptConnection() {
+    try {
+      java.net.Socket socket = this.serverSocket.accept();
+      System.out.println("Connection accepted on port " + this.serverSocket.getLocalPort());
+      return new Connection(socket);
+    } catch (IOException e) {
+      System.out.println(e.getStackTrace());
+      return null;
+    }
+  }
 
-
-
-
-
+  public void close() {
+    try {
+      this.serverSocket.close();
+    } catch (IOException e) {
+      System.out.println(e.getStackTrace());
+    }
+  }
 }
+
+

--- a/src/test/java/io/github/lottetreg/echo/ConnectionTest.java
+++ b/src/test/java/io/github/lottetreg/echo/ConnectionTest.java
@@ -3,29 +3,14 @@ package io.github.lottetreg.echo;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.net.Socket;
 
 public class ConnectionTest {
   @Test
-  public void returnsTheAcceptedSocket() throws IOException {
-    ServerSocket serverSocket = new MockServerSocket(8080);
-    Connection connection = new Connection(serverSocket);
+  public void itIsInitializedWithASocket() {
+    Socket socket = new Socket();
+    Connection connection = new Connection(socket);
 
-    Assert.assertEquals(true, connection.accept() instanceof Socket);
-  }
-
-  private class MockServerSocket extends ServerSocket {
-    MockServerSocket(int portNumber) throws IOException {
-      super(portNumber);
-    }
-
-    public Socket accept() {
-      return new ConnectionTest.MockSocket();
-    }
-  }
-
-  private class MockSocket extends Socket {
+    Assert.assertEquals(socket, connection.socket);
   }
 }

--- a/src/test/java/io/github/lottetreg/echo/EchoServerTest.java
+++ b/src/test/java/io/github/lottetreg/echo/EchoServerTest.java
@@ -8,10 +8,14 @@ import java.net.Socket;
 public class EchoServerTest {
   int portNumber = 8080;
 
+  @Test
   public void itWorks() throws IOException {
     Thread serverHandlerThread = new ServerHandlerThread();
     serverHandlerThread.start();
-    new Socket("0.0.0.0", portNumber);
+
+    Socket socket = new Socket("0.0.0.0", portNumber);
+
+    socket.close();
   }
 
   class ServerHandlerThread extends Thread {

--- a/src/test/java/io/github/lottetreg/echo/SocketTest.java
+++ b/src/test/java/io/github/lottetreg/echo/SocketTest.java
@@ -3,63 +3,73 @@ package io.github.lottetreg.echo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.ServerSocket;
 
 public class SocketTest {
+  private boolean calledAccept;
+  private Socket socket;
 
   private class MockServerSocket extends ServerSocket {
-
-    public boolean called = false;
-
-    public MockServerSocket() throws IOException {
-    }
+    public MockServerSocket() throws IOException {}
 
     public java.net.Socket accept() {
-      this.called = true;
+      SocketTest.this.calledAccept = true;
       return new java.net.Socket();
     }
   }
 
+  @Before
+  public void setUp() {
+    socket = new Socket();
+  }
+
+  @After
+  public void tearDown() {
+    socket.close();
+  }
+
   @Test
   public void testCreatesAServerSocket() {
-    Socket socket = new Socket();
     assertThat(socket.serverSocket, instanceOf(ServerSocket.class));
   }
 
   @Test
   public void testSetServerSocket() throws IOException {
     ServerSocket serverSocket = new ServerSocket();
-    Socket socket = new Socket();
 
     socket.setServerSocket(serverSocket);
 
-    assertEquals(socket.serverSocket, serverSocket);
+    assertEquals(serverSocket, socket.serverSocket);
   }
 
   @Test
-  public void testSetPort() throws IOException {
-    Socket socket = new Socket();
-
+  public void testSetPort() {
     socket.setPort(9000);
 
-    assertEquals(socket.serverSocket.getLocalPort(), 9000);
+    assertEquals(9000, socket.serverSocket.getLocalPort());
   }
 
   @Test
   public void testAcceptConnection() throws IOException {
     ServerSocket mockServerSocket = new MockServerSocket();
-    Socket socket = new Socket();
     socket.setServerSocket(mockServerSocket);
 
     socket.setPort(9000);
     socket.acceptConnection();
 
-    MockServerSocket mockSocket = (MockServerSocket) socket.serverSocket;
-    assertEquals(mockSocket.called, true);
+    assertEquals(true, calledAccept);
   }
 
+  @Test
+  public void testClose() {
+    socket.close();
 
+    assertEquals(true, socket.serverSocket.isClosed());
+  }
 }


### PR DESCRIPTION
I added these changes after pairing with Connor yesterday.

- added a Connection class (well, I rewrote it, since I already had a `Connection` but didn't want to use it in that way anymore)
- added the `close()` method to `Socket` and used it in the teardown of the Socket tests
- changed the `acceptConnection()` method on `Socket` to return a Connection
- Refactored `main()` to use the new abstractions we added