### PR TITLE
Create Readers with Builder Pattern

### DIFF
--- a/src/main/java/io/github/lottetreg/echo/Connection.java
+++ b/src/main/java/io/github/lottetreg/echo/Connection.java
@@ -23,8 +23,6 @@ public class Connection {
   public static class Builder {
     private Socket socket = new Socket();
 
-    public Builder() {}
-
     public Builder setSocket(Socket socket) {
       this.socket = socket;
       return this;

--- a/src/main/java/io/github/lottetreg/echo/Reader.java
+++ b/src/main/java/io/github/lottetreg/echo/Reader.java
@@ -30,13 +30,13 @@ public class Reader {
   }
 
   private BufferedReader newBufferedReader() {
-    InputStream inputStream = connection.getInputStream();
+    InputStream inputStream = this.connection.getInputStream();
     InputStreamReader streamReader = new InputStreamReader(inputStream);
     return new BufferedReader(streamReader);
   }
 
   public static class Builder {
-    public Connection connection = new Connection.Builder().build();
+    private Connection connection = new Connection.Builder().build();
 
     public Builder setConnection(Connection connection) {
       this.connection = connection;

--- a/src/main/java/io/github/lottetreg/echo/Reader.java
+++ b/src/main/java/io/github/lottetreg/echo/Reader.java
@@ -8,10 +8,6 @@ import java.io.InputStreamReader;
 public class Reader {
   public Connection connection;
 
-  Reader() {
-    this.connection = new Connection.Builder().build();
-  }
-
   Reader(Builder builder) {
     this.connection = builder.connection;
   }

--- a/src/main/java/io/github/lottetreg/echo/Reader.java
+++ b/src/main/java/io/github/lottetreg/echo/Reader.java
@@ -12,6 +12,10 @@ public class Reader {
     this.connection = new Connection.Builder().build();
   }
 
+  Reader(Builder builder) {
+    this.connection = builder.connection;
+  }
+
   public void setConnection(Connection connection) {
     this.connection = connection;
   }
@@ -29,5 +33,18 @@ public class Reader {
     InputStream inputStream = connection.getInputStream();
     InputStreamReader streamReader = new InputStreamReader(inputStream);
     return new BufferedReader(streamReader);
+  }
+
+  public static class Builder {
+    public Connection connection = new Connection.Builder().build();
+
+    public Builder setConnection(Connection connection) {
+      this.connection = connection;
+      return this;
+    }
+
+    public Reader build() {
+      return new Reader(this);
+    }
   }
 }

--- a/src/main/java/io/github/lottetreg/echo/Server.java
+++ b/src/main/java/io/github/lottetreg/echo/Server.java
@@ -10,7 +10,7 @@ public class Server {
     this.out = out;
     this.socket = new Socket();
     this.connection = new Connection.Builder().build();
-    this.reader = new Reader();
+    this.reader = new Reader.Builder().build();
   }
 
   public void start(int portNumber) {

--- a/src/test/java/io/github/lottetreg/echo/ReaderTest.java
+++ b/src/test/java/io/github/lottetreg/echo/ReaderTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -28,13 +27,6 @@ class MockConnection extends Connection {
 }
 
 public class ReaderTest {
-  private Reader reader;
-
-  @Before
-  public void setUp() {
-    reader = new Reader.Builder().build();
-  }
-
   @Test
   public void itIsCreatedWithABuilder() {
     Reader reader = new Reader.Builder().build();
@@ -62,6 +54,8 @@ public class ReaderTest {
 
   @Test
   public void testItHasAConnection() {
+    Reader reader = new Reader.Builder().build();
+
     assertThat(reader.connection, instanceOf(Connection.class));
   }
 

--- a/src/test/java/io/github/lottetreg/echo/ReaderTest.java
+++ b/src/test/java/io/github/lottetreg/echo/ReaderTest.java
@@ -9,27 +9,30 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.net.Socket;
+
+class MockConnection extends Connection {
+  MockConnection(Builder builder) {
+    super(builder);
+  }
+
+  public InputStream getInputStream() {
+    byte[] byteArray = "Some string".getBytes();
+    return new ByteArrayInputStream(byteArray);
+  }
+
+  public static class Builder extends Connection.Builder {
+    public MockConnection build() {
+      return new MockConnection(this);
+    }
+  }
+}
 
 public class ReaderTest {
   private Reader reader;
 
-  private class MockConnection extends Connection {
-    MockConnection(Builder builder) {
-      super(builder);
-    }
-  }
-
-  private class MockSocket extends Socket {
-    public InputStream getInputStream() {
-      byte[] byteArray = "Some string".getBytes();
-      return new ByteArrayInputStream(byteArray);
-    }
-  }
-
   @Before
   public void setUp() {
-    reader = new Reader();
+    reader = new Reader.Builder().build();
   }
 
   @Test
@@ -65,19 +68,19 @@ public class ReaderTest {
   @Test
   public void testSetConnection() {
     Connection connection = new Connection.Builder().build();
-
-    reader.setConnection(connection);
+    Reader reader = new Reader.Builder()
+            .setConnection(connection)
+            .build();
 
     assertEquals(reader.connection, connection);
   }
 
   @Test
   public void testReadLine() {
-    MockSocket socket = new MockSocket();
-    Connection connection = new MockConnection.Builder()
-            .setSocket(socket)
+    Connection connection = new MockConnection.Builder().build();
+    Reader reader = new Reader.Builder()
+            .setConnection(connection)
             .build();
-    reader.setConnection(connection);
 
     assertEquals(reader.readLine(), "Some string");
   }

--- a/src/test/java/io/github/lottetreg/echo/ReaderTest.java
+++ b/src/test/java/io/github/lottetreg/echo/ReaderTest.java
@@ -33,6 +33,31 @@ public class ReaderTest {
   }
 
   @Test
+  public void itIsCreatedWithABuilder() {
+    Reader reader = new Reader.Builder().build();
+
+    assertThat(reader, instanceOf(Reader.class));
+  }
+
+  @Test
+  public void itHasADefaultConnection() {
+    Reader reader = new Reader.Builder().build();
+
+    assertThat(reader.connection, instanceOf(Connection.class));
+  }
+
+  @Test
+  public void theConnectionCanBeSetThroughTheBuilder() {
+    Connection connection = new Connection.Builder().build();
+
+    Reader reader = new Reader.Builder()
+            .setConnection(connection)
+            .build();
+
+    assertEquals(reader.connection, connection);
+  }
+
+  @Test
   public void testItHasAConnection() {
     assertThat(reader.connection, instanceOf(Connection.class));
   }

--- a/src/test/java/io/github/lottetreg/echo/ServerTest.java
+++ b/src/test/java/io/github/lottetreg/echo/ServerTest.java
@@ -13,6 +13,22 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+class MockReader extends Reader {
+  MockReader(Builder builder) {
+    super(builder);
+  }
+
+  public String readLine() {
+    return "Some string";
+  }
+
+  public static class Builder extends Reader.Builder {
+    public MockReader build() {
+      return new MockReader(this);
+    }
+  }
+}
+
 @RunWith(Enclosed.class)
 public class ServerTest {
   private static ByteArrayOutputStream bytes = new ByteArrayOutputStream();
@@ -39,16 +55,10 @@ public class ServerTest {
       }
     }
 
-    private class MockReader extends Reader {
-      public String readLine() {
-        return "Some string";
-      }
-    }
-
     @Before
     public void setUp() {
       Socket socket = new MockSocket();
-      Reader reader = new MockReader();
+      Reader reader = new MockReader.Builder().build();
 
       server = new Server(out);
       server.setSocket(socket);


### PR DESCRIPTION
Same idea as before. It became necessary to start using the builder pattern in my mock classes too. Since you can't have static methods or classes inside nested classes, I moved the mock classes out of the test classes.

UPDATE: I just realized that I probably shouldn't have bothered using the Builder Pattern for the Reader class, since the `setConnection` method is actually meant to be used to set the connection after the Reader has been created. (It wasn't just a convenience for mocking/stubbing in tests.) Should I remove the use of the builder pattern here in a later PR (I've already created a couple more branches off of this one), or should I leave it as is?