### PR TITLE
User can send multiple messages

### DIFF
--- a/src/main/java/io/github/lottetreg/echo/Server.java
+++ b/src/main/java/io/github/lottetreg/echo/Server.java
@@ -24,7 +24,10 @@ public class Server {
     this.reader.setConnection(this.connection);
     this.writer.setConnection(this.connection);
 
-    this.writer.println(this.reader.readLine());
+    String input;
+    while((input = this.reader.readLine()) != null) {
+      this.writer.println(input);
+    }
   }
 
   public static class Builder {

--- a/src/test/java/io/github/lottetreg/echo/EchoServerTest.java
+++ b/src/test/java/io/github/lottetreg/echo/EchoServerTest.java
@@ -12,7 +12,7 @@ public class EchoServerTest {
   Socket socket;
 
   @Test
-  public void itWorks() throws IOException {
+  public void itEchoesTheClientsMessageBackToThem() throws IOException {
     startServer();
     socket = new Socket("localhost", portNumber);
     sendMessageToServer("Hello, World!");


### PR DESCRIPTION
Able to have a mocked method return a different value each time it is called, and able to expect a mocked method to receive expected arguments for all of the times it is called.

I wanted to create a version of the
`allow(something).to receive(:method).and_return([values])` and
`expect(something).to receive(:method).with([arguments])` concepts that I have grown so fond of in RSpec.